### PR TITLE
Fix bug with rolltemplate template; update for googleFont usage

### DIFF
--- a/lib/templates/sfc/fonts.scss
+++ b/lib/templates/sfc/fonts.scss
@@ -1,1 +1,0 @@
-// Import your google fonts here

--- a/lib/templates/sfc/rolltemplate.scss
+++ b/lib/templates/sfc/rolltemplate.scss
@@ -3,7 +3,7 @@
 @use './scss';
 // use the K-scaffold's sfc export:
 @use 'sfc';
-.sheet-rolltemplate-project-name{
+.sheet-rolltemplate-sheet-name{
   @include scss.variables;
   &.sheet-rolltemplate-darkmode{
     @include scss.darkVariables;

--- a/lib/templates/sfc/sheet-name.scss
+++ b/lib/templates/sfc/sheet-name.scss
@@ -3,10 +3,13 @@
 
 // Use the k-scaffold and assign it to the alias "k"
 @use 'k-scaffold' as k;
-// use any generic scss we might need.
-@use './scss';
+// Use K-scaffold and custom font import
+@use 'googleFont';
 // use the K-scaffold's sfc export:
 @use 'sfc';
+
+// use any generic scss we might need.
+@use './scss';
 
 // Use roll template styling
 @use './rolltemplate';


### PR DESCRIPTION
v2.1.1
- Fixed a bug with Roll template template file.
- Updated templates for use of `googleFont` mixin.