### PR TITLE
Add commented out instructions on dark mode dark sheet styling

### DIFF
--- a/lib/templates/sfc/sheet-name.scss
+++ b/lib/templates/sfc/sheet-name.scss
@@ -41,6 +41,14 @@ body{
         @include k.defaultStyles;
         @include scss.sheet;
         @include sfc.sheet;
+        
+        // Dark mode styling normally keeps a light colored sheet.  If you want
+        // a dark sheet, uncomment the following lines:
+        //
+        // background-color: var(--backColor);
+        // label {
+        //     color: var(--fontColor);
+        // }
       }
     }
   }

--- a/lib/templates/standard/general.scss
+++ b/lib/templates/standard/general.scss
@@ -35,6 +35,15 @@ body{
         // Include the styles for each of our components and sections. Note that sections are listed last so that they override the component styles if necessary.
         @include components.all;
         @include sections.all;
+
+        // Dark mode styling normally keeps a light colored sheet.  If you want
+        // a dark sheet, uncomment the following lines:
+        //
+        // background-color: var(--backColor);
+        // label {
+        //     color: var(--fontColor);
+        // }
+
         // Do any other generic styling that you need for your project
       }
     }


### PR DESCRIPTION
As per discord discussion, added instructions for creating a dark sheet in dark mode, but commented out.

We included both background color and input-label color.